### PR TITLE
Use TravisCI caching mechanism to speed up the compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ compiler:
 
 cache:
   directories:
-  - $HOME/moos-ivp
+  - $TRAVIS_BUILD_DIR/../moos-ivp/
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ os:
 compiler:
  - gcc
 
+cache:
+  directories:
+  - $HOME/moos-ivp
 
 addons:
   apt:


### PR DESCRIPTION
Caching the moos-ivp (15.5) folder not have to check it out and compile it at every test. Thus reducing the testing time from: ~3m45s to ~50s.

PS: Caching doesn't work on OSX.
